### PR TITLE
feat(winbar): hide winbar in git-mergetool

### DIFF
--- a/vim/vimrcs/lua/plugins/config/heirline/components/winbar.lua
+++ b/vim/vimrcs/lua/plugins/config/heirline/components/winbar.lua
@@ -15,6 +15,13 @@ local terminal = {
 
 return {
   fallthrough = false,
+  {
+    -- git mergetool
+    condition = function()
+      return vim.o.diff and vim.fn.winnr('$') == 3
+    end,
+    {}, -- empty winbar
+  },
   { -- A special winbar for terminals
     condition = function()
       return conditions.buffer_matches({ buftype = { "terminal" } })


### PR DESCRIPTION
Hide the winbar when `git mergetool` is running.
This is determined by checking if it is in diff mode and there are 3 windows.

Fixes #8